### PR TITLE
Fix ParameterTypeException in SpecialManageNamespaces

### DIFF
--- a/includes/SpecialManageNamespaces.php
+++ b/includes/SpecialManageNamespaces.php
@@ -22,7 +22,7 @@ class SpecialManageNamespaces extends SpecialPage {
 		
 		$out = $this->getOutput();
 		$out->enableOOUI();
-		$out->setPageTitle( $this->msg( 'managenamespaces-title' ) );
+		$out->setPageTitle( $this->msg( 'managenamespaces-title' )->text() );
 		$out->addWikiMsg( 'managenamespaces-intro' );
 
         $request = $this->getRequest();


### PR DESCRIPTION
Fixes #6: setPageTitle() expects a string, but was receiving a Message object.

The error was:
  Wikimedia\Assert\ParameterTypeException: Bad value for parameter $name: must be a string

Solution: Convert the Message object to a string using ->text() method before passing to setPageTitle().

Changed line 25 from:
  $out->setPageTitle( $this->msg( 'managenamespaces-title' ) );
To:
  $out->setPageTitle( $this->msg( 'managenamespaces-title' )->text() );

This aligns with MediaWiki's type-checking requirements as per OutputPage::setPageTitle() documentation.

I have tested this on the local version we are using at dcwwiki.org